### PR TITLE
Fix WGWrongCodeError Exceptions Being Thrown

### DIFF
--- a/wget.py
+++ b/wget.py
@@ -500,11 +500,12 @@ class WGError(Exception):
 
     def log(self):
         info = OrderedDict()
-        if self.cause is not None:
+        if hasattr(self, 'cause') and self.cause is not None:
             info['Caused by'] = repr(self.cause)
-        if self.info is not None:
+        if hasattr(self, 'info') and self.info is not None:
             info.update(self.info)
-        self.logger.error(self.url, self.msg, info)
+        if hasattr(self, 'msg') and hasattr(self, 'url'):
+            self.logger.error(self.url, self.msg, info)
 
     def __str__(self):
         return repr(self)


### PR DESCRIPTION
I was running into attributes not existing on the WGWrongCodeError object causing exceptions when avatars were 404'ing on Tumblr posts, which also caused those posts not to be saved. Just added a couple lines to check for the attributes' existence, which has fixed the exceptions on my end and appears to be saving the posts despite the avatar 404s.

Further details below, in case there's a better way than my solve:

`python ./tumblr_backup.py -O ../blogs_tumblr/blogname --json --save-video-tumblr --save-audio --save-notes --notes-limit 100 --tag-index -N 0 --no-post-clobber --internet-archive --reuse-json blogname`

```
Caught exception while saving post 5357295512:                                  
Traceback (most recent call last):                                              
  File "/home/lucible/nas-home/archives/archive/tumblr-utils_cebtenzzre/wget.py", line 635, in _retrieve_loop
    err, doctype = gethttp(url, hstat, doctype, logger, retry_counter, options) 
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
  File "/home/lucible/nas-home/archives/archive/tumblr-utils_cebtenzzre/wget.py", line 253, in gethttp
    err, doctype = process_response(url, hstat, doctype, logger, retry_counter, resp)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lucible/nas-home/archives/archive/tumblr-utils_cebtenzzre/wget.py", line 340, in process_response
    raise e                                                                     
wget.WGWrongCodeError: WGWrongCodeError(<wget.Logger object at 0x7f5338400f50>, 'https://64.media.tumblr.com/avatar_f76a691e3bd3_1280.png', 404, 'Not Found', HTTPHeaderDict({'Server': 'nginx', 'Date': 'Sat, 25 Nov 2023 00:28:12 GMT', 'Content-Type': 'text/plain', 'Content-Length': '14', 'Connection': 'keep-alive', 'ETag': '"655cda67-e"', 'X-nc': 'HIT dfw 1', 'Access-Control-Allow-Methods': 'GET', 'Access-Control-Allow-Origin': '*', 'Access-Control-Max-Age': '86400', 'Strict-Transport-Security': 'max-age=31536000; preload', 'Server-Timing': 'dc;desc=dfw, cache;desc=HIT;dur=0.0'}))
                                                                                
During handling of the above exception, another exception occurred:             
                                                                                
Traceback (most recent call last):                                              
  File "/home/lucible/nas-home/archives/archive/tumblr-utils_cebtenzzre/./tumblr_backup.py", line 1808, in _download_media_inner
    wget_retrieve(url, dstpath, post_id=self.ident, post_timestamp=self.post['timestamp'])
  File "/home/lucible/nas-home/archives/archive/tumblr-utils_cebtenzzre/wget.py", line 801, in __call__
    _retrieve_loop(hstat, url, file, post_id, post_timestamp, adjust_basename, self.options, self.log)
  File "/home/lucible/nas-home/archives/archive/tumblr-utils_cebtenzzre/wget.py", line 684, in _retrieve_loop
    raise oe                                                                    
wget.WGWrongCodeError: WGWrongCodeError(<wget.Logger object at 0x7f5338400f50>) 
                                                                                
During handling of the above exception, another exception occurred:             
                                                                                
Traceback (most recent call last):                                              
  File "/home/lucible/nas-home/archives/archive/tumblr-utils_cebtenzzre/./tumblr_backup.py", line 1960, in save_post
    f.write(self.get_post())                                                    
            ^^^^^^^^^^^^^^^                                                     
  File "/home/lucible/nas-home/archives/archive/tumblr-utils_cebtenzzre/./tumblr_backup.py", line 1838, in get_post
    content = self.get_content()                                                
              ^^^^^^^^^^^^^^^^^^                                                
  File "/home/lucible/nas-home/archives/archive/tumblr-utils_cebtenzzre/./tumblr_backup.py", line 1521, in get_content
    append_try('body')                                                          
  File "/home/lucible/nas-home/archives/archive/tumblr-utils_cebtenzzre/./tumblr_backup.py", line 1505, in append_try
    elt = re.sub(r'''(?i)(<img\s(?:[^>]*\s)?src\s*=\s*["'])(.*?)(["'][^>]*>)''',
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/re/__init__.py", line 185, in sub                   
    return _compile(pattern, flags).sub(repl, string, count)                    
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                    
  File "/home/lucible/nas-home/archives/archive/tumblr-utils_cebtenzzre/./tumblr_backup.py", line 1690, in get_inline_image
    saved_name = self.download_media(image_url, filename=image_filename)        
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^        
  File "/home/lucible/nas-home/archives/archive/tumblr-utils_cebtenzzre/./tumblr_backup.py", line 1782, in download_media
    return self._download_media_inner(url, get_path, path_parts, media_path)    
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    
  File "/home/lucible/nas-home/archives/archive/tumblr-utils_cebtenzzre/./tumblr_backup.py", line 1810, in _download_media_inner
    e.log()                                                                     
  File "/home/lucible/nas-home/archives/archive/tumblr-utils_cebtenzzre/wget.py", line 507, in log
    self.logger.error(self.url, self.msg, info)                                 
                                ^^^^^^^^                                        
AttributeError: 'WGWrongCodeError' object has no attribute 'msg'  
```