### PR TITLE
Fix: prettify and fix --json-info output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tumblr-backup"
-version = "1.6.3.dev0"
+version = "1.6.3"
 description = "An advanced tool for backing up Tumblr blogs."
 dynamic = ["readme"]
 requires-python = ">=3.10"
@@ -80,6 +80,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 include-package-data = true
+packages = ["tumblr_backup", "tumblr_backup.npf"]
 
 [tool.setuptools.package-data]
 tumblr_backup = [

--- a/tumblr_backup/main.py
+++ b/tumblr_backup/main.py
@@ -1304,10 +1304,25 @@ class TumblrBackup:
 
         if self.options.json_info:
             posts = resp[posts_key]
-            info = {'uuid': blog.get('uuid'),
+            if posts_key == 'posts':
+                info = {
+                    'blog': account,
+                    'uuid': blog.get('uuid'),
+                    'url': blog.get('url'),
+                    'title': blog.get('title'),
+                    'description': blog.get('description'),
                     'post_count': count_estimate,
-                    'last_post_ts': posts[0]['timestamp'] if posts else None}
+                    'last_posted_ts': blog.get('updated') or (posts[0]['timestamp'] if posts else None)
+                }
+            else:
+                info = {
+                    'blog': account,
+                    'liked_count': count_estimate,
+                    'last_liked_ts': posts[0]['liked_timestamp'] if posts else None
+                }
             json.dump(info, sys.stdout)
+            print("\n")
+            sys.stdout.flush()
             return
 
         if write_fro:
@@ -2628,6 +2643,9 @@ def main():
     if options.copy_notes is None:
         # Default to True if we may regenerate posts
         options.copy_notes = options.reuse_json and not options.no_post_clobber
+    if options.json_info and options.likes:
+        logger.info("Note: only use --json-info with -l for liked info."
+                    " More general info (and post related info) is available without -l.\n")
 
     # NB: this is done after setting implied options
     orig_options = vars(options).copy()


### PR DESCRIPTION
## Problem
`--json-info` has access to differing info depending on `-l`, which are not compatible.
The last updated timestamp was incorrect for liked posts (it took the post timestamp of the last liked post, not the like timestamp.)
## Fix
- Split print-out depending on `-l`, and add more info where available.
- Fix timestamp to be correct for likes.
- Add note when running with `-l` to alert to the fact that `--json-info -l` only gives info about likes.