### PR TITLE
Feature: --outdir multiblog & blosxom mode support

### DIFF
--- a/docs/operation.md
+++ b/docs/operation.md
@@ -37,7 +37,9 @@ The generated directory structure looks like this:
             style.css - the blog's style sheet
 ```
 
-The default `outdir` is the `blog-name`.
+The default `outdir` is the `blog-name`. If the `outdir` is set with `-O` or
+`--outdir`, and multiple blog names are passed to the command, a sub-folder is
+created within `outdir` per blog.
 
 ## Directory Structure with -D Option
 
@@ -154,7 +156,7 @@ In Blosxom format mode, the posts generated are saved in a format suitable for
 re-publishing in [Blosxom](http://www.blosxom.com) with the [Meta
 plugin](http://www.blosxom.com/plugins/meta/meta.htm). Images are not
 downloaded; instead, the image links point back to the original image on
-Tumblr. The posts are saved in the current folder with a `.txt` extension. The
+Tumblr. The posts are saved in `outdir` with a `.txt` extension. The
 index is not updated.
 
 ## Limiting Backed Up Posts

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -15,7 +15,9 @@ positional arguments:
 options:
   -h, --help            show this help message and exit
   -O OUTDIR, --outdir OUTDIR
-                        set the output directory (default: blog-name)
+                        set the output directory (default: <blog-name>). If set,
+                        blog sub-folders are added automatically if multiple
+                        blogs are passed.
   -D, --dirs            save each post in its own folder
   -q, --quiet           suppress progress messages
   -i, --incremental     incremental backup mode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tumblr-backup"
-version = "1.6.3.dev0"
+version = "1.6.3"
 description = "An advanced tool for backing up Tumblr blogs."
 dynamic = ["readme"]
 requires-python = ">=3.10"
@@ -80,6 +80,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 include-package-data = true
+packages = ["tumblr_backup", "tumblr_backup.npf"]
 
 [tool.setuptools.package-data]
 tumblr_backup = [

--- a/tumblr_backup/main.py
+++ b/tumblr_backup/main.py
@@ -2495,7 +2495,9 @@ def main():
                         version=f'%(prog)s {importlib.metadata.version("tumblr-backup")}')
     postexist_group = parser.add_mutually_exclusive_group()
     reblog_group = parser.add_mutually_exclusive_group()
-    parser.add_argument('-O', '--outdir', help='set the output directory (default: blog-name)')
+    parser.add_argument('-O', '--outdir',
+                        help='set the output directory (default: <blog-name>).'
+                        ' If set, blog sub-folders are added automatically if multiple blogs are passed.')
     parser.add_argument('-D', '--dirs', action='store_true', help='save each post in its own folder')
     parser.add_argument('-q', '--quiet', action='store_true', help='suppress progress messages')
     postexist_group.add_argument('-i', '--incremental', action='store_true', help='incremental backup mode')

--- a/tumblr_backup/main.py
+++ b/tumblr_backup/main.py
@@ -2573,10 +2573,10 @@ def main():
     parser.add_argument('blogs', nargs='*')
     options = parser.parse_args()
 
+    if not options.blogs:
+        parser.error('Missing blog-name')
     options.blogs = list(set(options.blogs))  # remove duplicate blog names
     blogs = options.blogs
-    if not blogs:
-        parser.error('Missing blog-name')
 
     logger.set_quiet(options.quiet)
     if options.json_info:

--- a/tumblr_backup/main.py
+++ b/tumblr_backup/main.py
@@ -524,7 +524,7 @@ class ApiParser:
             if status == 403 and self.options.likes:
                 logger.error('HTTP 403: Most likely {} does not have public likes.\n'.format(self.account))
                 return None
-            logger.error('URL is {}?{}\n[FATAL] {} API repsonse: HTTP {} {}\n{}'.format(
+            logger.error('URL is {}?{}\n[FATAL] {} API response: HTTP {} {}\n{}'.format(
                 base, urlencode(params),
                 'Error retrieving' if doc is None else 'Non-OK',
                 status, reason,
@@ -532,7 +532,7 @@ class ApiParser:
             ))
             if status == 401 and self.dashboard_only_blog:
                 logger.error("This is a dashboard-only blog, so you probably don't have the right cookies.{}\n".format(
-                    '' if self.options.cookiefile else ' Try --cookiefile.',
+                    ' Try refreshing them.' if self.options.cookiefile else ' Try --cookiefile.',
                 ))
             return None
         if doc is None:
@@ -1226,12 +1226,10 @@ class TumblrBackup:
         if self.options.json_info:
             pass  # Not going to save anything
         elif self.options.blosxom:
-            save_folder = root_folder
             post_ext = '.txt'
             post_dir = os.curdir
             post_class: type[TumblrPost] = BlosxomPost
         else:
-            save_folder = join(root_folder, self.options.outdir or account)
             media_folder = path_to(media_dir)
             if self.options.dirs:
                 post_ext = ''
@@ -1239,6 +1237,11 @@ class TumblrBackup:
             post_class = TumblrPost
             have_custom_css = os.access(path_to(custom_css), os.R_OK)
 
+        if len(self.options.blogs) > 1:
+            save_folder = join(root_folder, self.options.outdir or '', account)
+        else:
+            save_folder = join(root_folder, self.options.outdir or account)
+        
         self.post_count = 0
         self.filter_skipped = 0
 
@@ -2568,6 +2571,7 @@ def main():
     parser.add_argument('blogs', nargs='*')
     options = parser.parse_args()
 
+    options.blogs = list(set(options.blogs))  # remove duplicate blog names
     blogs = options.blogs
     if not blogs:
         parser.error('Missing blog-name')
@@ -2590,8 +2594,6 @@ def main():
         parser.error('--skip: skip must not be negative')
     if options.posts_per_page < 0:
         parser.error('--posts-per-page: posts per page must not be negative')
-    if options.outdir and len(blogs) > 1:
-        parser.error('-O can only be used for a single blog-name')
     if options.dirs and options.tag_index:
         parser.error('-D cannot be used with --tag-index')
     if options.cookiefile is not None and not os.access(options.cookiefile, os.R_OK):


### PR DESCRIPTION
## Problem
`-O`/`--outdir` was only supported if a single blog was passed, and was ignored entirely if in blosxom mode (`-b`)
## Fix
- Blosxom mode now behaves the same as otherwise in terms of save location
- the save location is determined as follows:

|                 | without -O \<dir\>   | with -O \<dir\>     |
| ---------- | ----------------------  | -------------------- |
| 1 blog     | \<blog\>                   | \<dir\>                  |
| 2+ blogs | \<blog\>                   | \<dir\>/\<blog\> |

Additional change: blog names are de-duplicated.