### PR TITLE
Feature: --force-dashonly

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -94,9 +94,9 @@ options:
   --json-info           Just print some info for each blog, don't make a
                         backup
   --force-dashonly      Force the use of internal API (normally only used for
-                        dashboard-only blogs). Posts marked explicit are
-                        possible to archive this way for blogs the cookies are
-                        valid for.
+                        dashboard-only blogs). Private or explicit posts are
+                        possible to archive this way for blogs the cookies
+                        are valid for
 ```
 
 ## Arguments

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -93,6 +93,10 @@ options:
                         line
   --json-info           Just print some info for each blog, don't make a
                         backup
+  --force-dashonly      Force the use of internal API (normally only used for
+                        dashboard-only blogs). Posts marked explicit are
+                        possible to archive this way for blogs the cookies are
+                        valid for.
 ```
 
 ## Arguments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tumblr-backup"
-version = "1.6.3.dev0"
+version = "1.6.3"
 description = "An advanced tool for backing up Tumblr blogs."
 dynamic = ["readme"]
 requires-python = ">=3.10"
@@ -80,6 +80,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 include-package-data = true
+packages = ["tumblr_backup", "tumblr_backup.npf"]
 
 [tool.setuptools.package-data]
 tumblr_backup = [

--- a/tumblr_backup/main.py
+++ b/tumblr_backup/main.py
@@ -2573,7 +2573,8 @@ def main():
                         help="Just print some info for each blog, don't make a backup")
     parser.add_argument('--force-dashonly', action='store_true',
                         help='Force the use of internal API (normally only used for dashboard-only blogs).'
-                        ' Posts marked explicit are possible to archive this way for blogs the cookies are valid for.')
+                        ' Private or explicit posts are possible to archive this way for blogs the cookies'
+                        ' are valid for')
 
     parser.add_argument('blogs', nargs='*')
     options = parser.parse_args()
@@ -2606,7 +2607,7 @@ def main():
         parser.error('-D cannot be used with --tag-index')
     if options.cookiefile is not None and not os.access(options.cookiefile, os.R_OK):
         parser.error('--cookiefile: file cannot be read')
-    if options.force_dashonly is not None and options.cookiefile is None:
+    if options.force_dashonly and options.cookiefile is None:
         parser.error('--force-dashonly requires valid cookies. Try --cookiefile')
     if options.notes_limit is not None:
         if not options.save_notes:

--- a/tumblr_backup/main.py
+++ b/tumblr_backup/main.py
@@ -512,7 +512,13 @@ class ApiParser:
             ))
             return None
 
-        if not 200 <= status < 300:
+        if self.dashboard_only_blog is None and self.options.force_dashonly:
+            # Force the use of the internal API to parse a blog
+            self.dashboard_only_blog = True
+            logger.info("Forcing tumblr-backup into dashboard-only blog mode; trying internal API\n", account=True)
+            self._tb.get_npf_renderer(self.account)  # fail/warn fast if unavailable
+            return self.apiparse(count, start)  # Recurse once
+        elif not 200 <= status < 300:
             # Detect dashboard-only blogs by the error codes
             if status == 404 and self.dashboard_only_blog is None and not (doc is None or self.options.likes):
                 errors = doc.get('errors', ())
@@ -2565,6 +2571,10 @@ def main():
                         help='file containing a list of post IDs to save, one per line')
     parser.add_argument('--json-info', action='store_true',
                         help="Just print some info for each blog, don't make a backup")
+    parser.add_argument('--force-dashonly', action='store_true',
+                        help='Force the use of internal API (normally only used for dashboard-only blogs).'
+                        ' Posts marked explicit are possible to archive this way for blogs the cookies are valid for.')
+
     parser.add_argument('blogs', nargs='*')
     options = parser.parse_args()
 
@@ -2596,6 +2606,8 @@ def main():
         parser.error('-D cannot be used with --tag-index')
     if options.cookiefile is not None and not os.access(options.cookiefile, os.R_OK):
         parser.error('--cookiefile: file cannot be read')
+    if options.force_dashonly is not None and options.cookiefile is None:
+        parser.error('--force-dashonly requires valid cookies. Try --cookiefile')
     if options.notes_limit is not None:
         if not options.save_notes:
             parser.error('--notes-limit requires --save-notes')


### PR DESCRIPTION
## Problem
Posts on your own blog that are marked explicit by tumblr (by whatever criteria of theirs) or are private posts, are not accessible via the scraping API (regardless of `--cookiefile`)
## Feature
`--force-dashonly` forces tumblr-backup to behave like the blog is dashboard-only, and thus those posts are accessible again, as long as the cookies are valid for that particular blog (i.e. they have to be your posts)