### PR TITLE
Disable yt-dlp progress bar

### DIFF
--- a/tumblr_backup/main.py
+++ b/tumblr_backup/main.py
@@ -1781,6 +1781,7 @@ class TumblrPost:
         ydl_options = {
             'outtmpl': join(self.media_folder, filetmpl),
             'quiet': True,
+            'noprogress': True,
             'restrictfilenames': True,
             'noplaylist': True,
             'continuedl': True,


### PR DESCRIPTION
When downloading blogs with (external) videos the console output becomes polluted with yt-dlps progress bar, making the entire output difficult to read.

The script sets yt-dlp to "quiet" mode but that does not actually disable the progress bar (it just redirects all output intended for the screen to stderr). This patch adds the correct parameter to disable the progress bar fully. Warning and error logs are unaffected by this change and will continue to appear as normal.